### PR TITLE
fix: restore OpenOCD scripts/ search path for bundled releases

### DIFF
--- a/src/open_ocd_task.rs
+++ b/src/open_ocd_task.rs
@@ -138,11 +138,7 @@ where
     // search path — add the directory if it exists.
     let scripts_folder = dirs::get_exe_dir()?.join("scripts");
     if scripts_folder.is_dir() {
-        let scripts_str = scripts_folder
-            .into_os_string()
-            .into_string()
-            .map_err(|_| "Failed to convert scripts path to string")?;
-        cmd.args(&["-s", &scripts_str]);
+        cmd.arg("-s").arg(&scripts_folder);
     }
 
     let mut child = cmd

--- a/src/open_ocd_task.rs
+++ b/src/open_ocd_task.rs
@@ -123,7 +123,7 @@ where
         .into_string()
         .map_err(|_| "Failed to convert tmp_dir to string.")?;
 
-    let cmd = cmd.args(&[
+    cmd.args(&[
         "-s",
         &config_folder,
         "-s",
@@ -131,6 +131,19 @@ where
         "-s",
         &ws_foler,
     ]);
+
+    // The xpack-bundled OpenOCD ships its standard scripts alongside the
+    // executable in `<exe_dir>/scripts/`. Our .cfg files reference these via
+    // `source [find interface/...]`, which only resolves through OpenOCD's
+    // search path — add the directory if it exists.
+    let scripts_folder = dirs::get_exe_dir()?.join("scripts");
+    if scripts_folder.is_dir() {
+        let scripts_str = scripts_folder
+            .into_os_string()
+            .into_string()
+            .map_err(|_| "Failed to convert scripts path to string")?;
+        cmd.args(&["-s", &scripts_str]);
+    }
 
     let mut child = cmd
         .stdout(Stdio::piped())


### PR DESCRIPTION
## Summary
Hotfix for #8.

A cleanup commit during the wireless-stack PR (#5) dropped the `-s scripts` argument passed to OpenOCD, on the assumption that it was a leftover from the old script-dir layout. It wasn't.

The xpack-bundled release archive places OpenOCD's standard scripts (interface/, target/, ...) at `<install>/scripts/` next to the binary. Our [.cfg files](configs/) load these with `source [find interface/stlink.cfg]` etc., which only resolves through OpenOCD's search path. Without `-s <scripts-path>`, the bundled OpenOCD falls back to its compiled-in install prefix, which doesn't match the flat layout — first flash on a fresh release archive fails with `Can't find interface/stlink.cfg`.

This restores the search path, but with two improvements over the original:

- **Absolute path** built from `dirs::get_exe_dir()` instead of the bare relative `"scripts"`, so it works regardless of the user's CWD.
- **Existence-guarded** via `is_dir()`, so a system-OpenOCD setup (where `<exe_dir>/scripts/` doesn't exist) keeps using OpenOCD's compiled-in defaults instead of getting a useless `-s` arg.

## Test plan
- [ ] `cargo run` from the repo root: DapLink unlock/erase/flash still resolves via the system OpenOCD (no `<exe_dir>/scripts/` present, `-s` arg skipped).
- [ ] Build a fresh release archive locally (`cargo build --release` + manually mirror the workflow's archive layout into a tmpdir with `configs/`, `wireless_stack/`, `scripts/`, `openocd`); run the binary; confirm the unlock step finds `interface/stlink.cfg`.
- [ ] WB55 wireless-stack flow: flash operator (uses `wb5x.cfg` which `source [find interface/cmsis-dap.cfg]`) succeeds with the bundled scripts path.