### PR TITLE
build: validate PRs and mirror release matrix in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install packages
-        run: sudo apt install libatk1.0-dev pkg-config libgtk-3-dev libudev-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libatk1.0-dev pkg-config libgtk-3-dev libudev-dev
 
       - name: Install Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build
         run: cargo build --release --locked
@@ -36,13 +38,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install packages
-        run: sudo apt install libatk1.0-dev pkg-config libgtk-3-dev libudev-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libatk1.0-dev pkg-config libgtk-3-dev libudev-dev
 
       - name: Install Rust + clippy + rustfmt
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          "$HOME/.cargo/bin/rustup" component add clippy rustfmt
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
 
       - name: cargo fmt --check
         continue-on-error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,18 @@ on:
   push:
     branches:
         - main
+  pull_request:
+    branches:
+        - main
 
 jobs:
-  ci:
-    name: "C.I"
-    runs-on: ubuntu-latest
+  build:
+    name: "Build (${{matrix.os}})"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
 
@@ -19,5 +26,28 @@ jobs:
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-      - name: Build ubuntu version
+      - name: Build
         run: cargo build --release --locked
+
+  lint:
+    name: "Lint (informational)"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install packages
+        run: sudo apt install libatk1.0-dev pkg-config libgtk-3-dev libudev-dev
+
+      - name: Install Rust + clippy + rustfmt
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          "$HOME/.cargo/bin/rustup" component add clippy rustfmt
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: cargo fmt --check
+        continue-on-error: true
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        continue-on-error: true
+        run: cargo clippy --release --locked --all-targets


### PR DESCRIPTION
## Summary
The current CI only triggers on push-to-main/manual dispatch, builds a single ubuntu-latest image, and runs no lints. This PR addresses each:

- **Validate PRs before merge.** Add a `pull_request` trigger so changes get a green CI check before being merged into main, instead of after.
- **Match the release matrix.** Switch the build job from `ubuntu-latest` to a matrix of `ubuntu-22.04` + `ubuntu-24.04`, the same OSes [release.yaml](.github/workflows/release.yaml) targets. Avoids the kind of version-specific surprise (e.g. missing `libudev-dev`, glibc differences) that PR #5 hit.
- **Surface lint signal.** Add a separate `lint` job running `cargo fmt --check` and `cargo clippy --release --locked --all-targets`.

The lint job is **informational** (`continue-on-error: true`) for now: there are currently 41 clippy warnings and several files are not fmt-clean, so making it blocking would force a big cleanup commit. The signal still shows up in the Checks tab so we can address it in a follow-up PR and flip the flag to blocking once it's clean.

## Test plan
- [x] CI runs on this very PR (sanity check that the new `pull_request` trigger fires).
- [x] Both matrix jobs `Build (ubuntu-22.04)` and `Build (ubuntu-24.04)` complete with `cargo build --release --locked`.
- [x] `Lint (informational)` job runs and exits green even with non-zero clippy/fmt counts.
- [ ] After merge, push-to-main still triggers the same set (existing behavior preserved).

## Follow-ups (not in this PR)
- Cleanup commit running `cargo fmt --all` once.
- Cleanup PR to address the 41 clippy warnings, then drop `continue-on-error: true` so lint becomes blocking.