### PR TITLE
chore: cargo fmt --all

### DIFF
--- a/src/open_ocd_task.rs
+++ b/src/open_ocd_task.rs
@@ -123,14 +123,7 @@ where
         .into_string()
         .map_err(|_| "Failed to convert tmp_dir to string.")?;
 
-    cmd.args(&[
-        "-s",
-        &config_folder,
-        "-s",
-        &tmp_folder,
-        "-s",
-        &ws_foler,
-    ]);
+    cmd.args(&["-s", &config_folder, "-s", &tmp_folder, "-s", &ws_foler]);
 
     // The xpack-bundled OpenOCD ships its standard scripts alongside the
     // executable in `<exe_dir>/scripts/`. Our .cfg files reference these via

--- a/src/open_ocd_task.rs
+++ b/src/open_ocd_task.rs
@@ -113,17 +113,17 @@ where
         .into_string()
         .map_err(|_| "Failed to convert config path to string")?;
 
-    let ws_foler = dirs::get_wireless_stack_dir()?
+    let ws_folder = dirs::get_wireless_stack_dir()?
         .into_os_string()
         .into_string()
-        .map_err(|_| "Failed to convert config path to string")?;
+        .map_err(|_| "Failed to convert wireless stack path to string")?;
 
     let tmp_folder = dirs::get_tmp_dir()?
         .into_os_string()
         .into_string()
         .map_err(|_| "Failed to convert tmp_dir to string.")?;
 
-    cmd.args(&["-s", &config_folder, "-s", &tmp_folder, "-s", &ws_foler]);
+    cmd.args(&["-s", &config_folder, "-s", &tmp_folder, "-s", &ws_folder]);
 
     // The xpack-bundled OpenOCD ships its standard scripts alongside the
     // executable in `<exe_dir>/scripts/`. Our .cfg files reference these via

--- a/src/ui/tab_wireless_stack.rs
+++ b/src/ui/tab_wireless_stack.rs
@@ -243,9 +243,7 @@ impl TabWirelessStack {
                     None => {
                         Self::send_log(
                             &mut o,
-                            LogType::Error(
-                                "Flash failed: OpenOCD terminated by signal".into(),
-                            ),
+                            LogType::Error("Flash failed: OpenOCD terminated by signal".into()),
                         )
                         .await;
                         Self::send_step(&mut o, FwStep::Ready).await;
@@ -365,9 +363,7 @@ impl TabWirelessStack {
                     None => {
                         Self::send_log(
                             &mut o,
-                            LogType::Error(
-                                "Flash failed: OpenOCD terminated by signal".into(),
-                            ),
+                            LogType::Error("Flash failed: OpenOCD terminated by signal".into()),
                         )
                         .await;
                         Self::send_step(&mut o, FwStep::Ready).await;
@@ -472,9 +468,7 @@ impl TabWirelessStack {
                     None => {
                         Self::send_log(
                             &mut o,
-                            LogType::Error(
-                                "Flash failed: OpenOCD terminated by signal".into(),
-                            ),
+                            LogType::Error("Flash failed: OpenOCD terminated by signal".into()),
                         )
                         .await;
                         Self::send_step(&mut o, FwStep::Ready).await;


### PR DESCRIPTION
## Summary
Mechanical reformat to make the codebase fmt-clean.

The recent wireless-stack PR (#5) introduced a few spots that didn't match `rustfmt` defaults. With #12 having added `cargo fmt --check` to the lint job (currently informational, `continue-on-error: true`), this PR clears its output.

Diff is tiny — only 2 files actually had drift, total of ~17 lines.

## Follow-up (separate PR)
Once this lands, flip `continue-on-error: true` to `false` on the fmt step in [.github/workflows/ci.yaml](.github/workflows/ci.yaml) so future drift becomes a blocking failure rather than just a warning.

## Test plan
- [ ] `cargo build --release --locked` still passes (matrix + main).
- [ ] `cargo fmt --all -- --check` returns 0 (verify in the lint job log).