### PR TITLE
fix: flush remaining OpenOCD log lines after process exits

### DIFF
--- a/src/open_ocd_task.rs
+++ b/src/open_ocd_task.rs
@@ -186,11 +186,14 @@ where
     let output: ExitStatus;
     let mut tmp_deque: VecDeque<LogType> = VecDeque::new();
 
-    loop {
-        if let Ok(mut deque) = mutex_messages.lock() {
-            tmp_deque = deque.clone();
-            deque.clear();
+    let drain = |tmp_deque: &mut VecDeque<LogType>, mutex: &Arc<Mutex<VecDeque<LogType>>>| {
+        if let Ok(mut deque) = mutex.lock() {
+            tmp_deque.extend(deque.drain(..));
         }
+    };
+
+    loop {
+        drain(&mut tmp_deque, &mutex_messages);
 
         while let Some(msg) = tmp_deque.pop_front() {
             if let Some(ref mut s) = sender {
@@ -204,6 +207,20 @@ where
             output = status;
             let _ = thread_stdout.join();
             let _ = thread_stderr.join();
+
+            // Final drain: the reader threads may have pushed lines after the
+            // last in-loop drain and before they finished. Without this pass,
+            // the very last OpenOCD output (often the diagnostic on failure)
+            // would be silently dropped.
+            drain(&mut tmp_deque, &mutex_messages);
+            while let Some(msg) = tmp_deque.pop_front() {
+                if let Some(ref mut s) = sender {
+                    let _ = s.send(MSG::log(msg)).await;
+                } else {
+                    logs.push(msg);
+                }
+            }
+
             break;
         }
 


### PR DESCRIPTION
## Summary
Closes #9.

`run_command_sender` polls the OpenOCD child process and drains queued log lines into the in-app sender. Between the last in-loop drain and the moment `try_wait()` returns `Some(...)`, the reader threads can still push lines into the mutex. After joining the threads (which guarantees they're done writing) the loop broke out **without one last drain** — those final messages stayed in the mutex and were silently dropped from the UI.

That's exactly when OpenOCD emits the diagnostic that explains why a flash failed (`** Error: target halted unexpectedly`, `** verification failed**`, transport errors, etc.). Users were seeing a generic `Exit code: 1` with no context.

This PR extracts the drain into a tiny closure shared by the polling loop and a new post-exit pass, run after the reader threads are joined and before `break`. No behavior change in the success path.

## Test plan
- [ ] Trigger a deliberate failure (wrong target, missing probe) and confirm the OpenOCD failure message now appears in the log widget instead of disappearing.
- [ ] Successful flash flow still streams logs progressively and ends cleanly without duplicates.
- [ ] No CPU regression — the polling loop's 50 ms `Timer::after` is unchanged.