### PR TITLE
fix: ignore window close while a flash is in progress

### DIFF
--- a/src/ui/main_window.rs
+++ b/src/ui/main_window.rs
@@ -56,15 +56,15 @@ impl MainWindow {
                         return Task::none();
                     }
                     iced::window::Event::CloseRequested => {
-                        // Suppress the close while a flash is in progress so
-                        // OpenOCD (or the FUS upgrade) isn't killed mid-write.
-                        // The opacity overlay already signals the busy state
-                        // visually; the user can SIGTERM if they really need
-                        // out, but a misclick on the X shouldn't brick the
-                        // device.
+                        // Suppress the close while an operation is in progress
+                        // so OpenOCD (or the FUS upgrade) isn't interrupted
+                        // mid-action. The opacity overlay already signals the
+                        // busy state visually; the user can force-quit / end
+                        // task the app if they really need out, but a misclick
+                        // on the X shouldn't brick the device.
                         if self.tab_daplink.is_busy() || self.tab_ws.is_busy() {
                             eprintln!(
-                                "Close request ignored: a flash is in progress."
+                                "Close request ignored: an operation is in progress."
                             );
                             return Task::none();
                         }

--- a/src/ui/main_window.rs
+++ b/src/ui/main_window.rs
@@ -56,6 +56,19 @@ impl MainWindow {
                         return Task::none();
                     }
                     iced::window::Event::CloseRequested => {
+                        // Suppress the close while a flash is in progress so
+                        // OpenOCD (or the FUS upgrade) isn't killed mid-write.
+                        // The opacity overlay already signals the busy state
+                        // visually; the user can SIGTERM if they really need
+                        // out, but a misclick on the X shouldn't brick the
+                        // device.
+                        if self.tab_daplink.is_busy() || self.tab_ws.is_busy() {
+                            eprintln!(
+                                "Close request ignored: a flash is in progress."
+                            );
+                            return Task::none();
+                        }
+
                         match dirs::get_settings_dir() {
                             Ok(settings_dir) => {
                                 let fields_file = settings_dir.join(SETTINGS_FILE);

--- a/src/ui/tab_daplink.rs
+++ b/src/ui/tab_daplink.rs
@@ -38,9 +38,10 @@ pub struct TabDaplink {
 }
 
 impl TabDaplink {
-    /// True while a flash sequence (or a file browse) is running. Used by
-    /// `MainWindow` to suppress window-close requests during a flash so the
-    /// OpenOCD child isn't killed mid-operation.
+    /// True while an operation that should not be interrupted is running:
+    /// a flash sequence, or a (modal) file-browse. Used by `MainWindow` to
+    /// suppress window-close requests so the OpenOCD child isn't killed
+    /// mid-write.
     pub fn is_busy(&self) -> bool {
         self.is_readonly
     }

--- a/src/ui/tab_daplink.rs
+++ b/src/ui/tab_daplink.rs
@@ -38,6 +38,13 @@ pub struct TabDaplink {
 }
 
 impl TabDaplink {
+    /// True while a flash sequence (or a file browse) is running. Used by
+    /// `MainWindow` to suppress window-close requests during a flash so the
+    /// OpenOCD child isn't killed mid-operation.
+    pub fn is_busy(&self) -> bool {
+        self.is_readonly
+    }
+
     pub fn update(&mut self, message: TabDaplinkMessage) -> Task<Message> {
         match message {
             TabDaplinkMessage::LogMessage(log) => self.log_widget.push(log),

--- a/src/ui/tab_wireless_stack.rs
+++ b/src/ui/tab_wireless_stack.rs
@@ -103,9 +103,9 @@ const ALL_STACK: [WirelessStackFile; 21] = [
 ];
 
 impl TabWirelessStack {
-    /// True while a flash sequence is running. Used by `MainWindow` to
-    /// suppress window-close requests so the OpenOCD child or the FUS
-    /// upgrade isn't killed mid-operation.
+    /// True while an operation that should not be interrupted is running.
+    /// Used by `MainWindow` to suppress window-close requests so neither
+    /// the OpenOCD child nor an in-flight FUS upgrade gets cut mid-action.
     pub fn is_busy(&self) -> bool {
         self.is_readonly
     }

--- a/src/ui/tab_wireless_stack.rs
+++ b/src/ui/tab_wireless_stack.rs
@@ -103,6 +103,13 @@ const ALL_STACK: [WirelessStackFile; 21] = [
 ];
 
 impl TabWirelessStack {
+    /// True while a flash sequence is running. Used by `MainWindow` to
+    /// suppress window-close requests so the OpenOCD child or the FUS
+    /// upgrade isn't killed mid-operation.
+    pub fn is_busy(&self) -> bool {
+        self.is_readonly
+    }
+
     pub fn view(&self) -> Element<Message> {
         let grid_fields = grid!(
             grid_row!(


### PR DESCRIPTION
## Summary
Closes #6.

If the user clicks the close button (or sends a window-close request via the WM) during a flash, the OpenOCD child currently gets dropped immediately, which can leave the target in a half-flashed state requiring manual recovery on the next attempt. This PR adds a guard so the close becomes a no-op while either tab is busy.

### Implementation
- New `pub fn is_busy(&self) -> bool` accessor on both `TabDaplink` and `TabWirelessStack`, exposing the existing `is_readonly` flag they already use to gray out controls during a flash.
- In `MainWindow`'s `CloseRequested` handler, short-circuit before the save-and-close path if either tab reports busy. Logs to stderr for traceability.

### What this does NOT change
- The save-on-close behavior is preserved for the idle case.
- The opacity overlay during a flash still indicates the busy state visually — the X doing nothing is consistent with the rest of the UI being non-interactable.
- A `SIGTERM` (or kill from another tool) remains the escape hatch if a flash genuinely hangs. We're not making the app unkillable, only making the X discreet.

### Test plan
- [x] `cargo build --release --locked` green locally.
- [x] `cargo test --release --locked` green (4 existing tests still pass).
- [ ] Manual: launch a flash, click X — window stays open, stderr shows "Close request ignored".
- [ ] Manual: idle state, click X — window closes, settings saved as before.